### PR TITLE
fix: non cluster return

### DIFF
--- a/cluster-node-cache.js
+++ b/cluster-node-cache.js
@@ -126,6 +126,8 @@ module.exports = function(cluster, options, namespace) {
     cluster.on('online', function(worker) {
       worker.on('message', incoming_message.bind(null, worker));
     });
+    
+    return cache;
   } else {
     var ClusterCache = {};
     var resolve_dict = {};


### PR DESCRIPTION
When the library is initialised in a non cluster environment, nothing is returned.